### PR TITLE
Update Pekka Kana 2 to 1.5.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.pistegamez.PekkaKana2.metainfo.xml
+++ b/net.pistegamez.PekkaKana2.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>net.pistegamez.PekkaKana2</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>BSD-2-Clause</project_license>
+  <project_license>CC-BY-NC-4.0</project_license>
   <launchable type="desktop-id">net.pistegamez.PekkaKana2.desktop</launchable>
   <name>Pekka Kana 2</name>
   <developer_name>Piste Gamez</developer_name>
@@ -25,7 +25,7 @@
   </screenshots>
   <url type="homepage">https://pistegamez.net/game_pk2.html</url>
   <releases>
-    <release version="1.2.7" date="2020-09-20"/>
+    <release version="1.5.1" date="2026-04-9"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/net.pistegamez.PekkaKana2.metainfo.xml
+++ b/net.pistegamez.PekkaKana2.metainfo.xml
@@ -25,7 +25,6 @@
   </screenshots>
   <url type="homepage">https://pistegamez.net/game_pk2.html</url>
   <url type="vcs-browser">https://github.com/SaturninTheAlien/pk2_greta</url>
-  
   <releases>
     <release version="1.5.2" date="2026-04-23">
       <description>

--- a/net.pistegamez.PekkaKana2.metainfo.xml
+++ b/net.pistegamez.PekkaKana2.metainfo.xml
@@ -25,7 +25,7 @@
   </screenshots>
   <url type="homepage">https://pistegamez.net/game_pk2.html</url>
   <releases>
-    <release version="1.5.1" date="2026-04-9"/>
+    <release version="1.5.2" date="2026-04-23"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/net.pistegamez.PekkaKana2.metainfo.xml
+++ b/net.pistegamez.PekkaKana2.metainfo.xml
@@ -24,8 +24,27 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://pistegamez.net/game_pk2.html</url>
+  <url type="vcs-browser">https://github.com/SaturninTheAlien/pk2_greta</url>
+  
   <releases>
-    <release version="1.5.2" date="2026-04-23"/>
+    <release version="1.5.2" date="2026-04-23">
+      <description>
+        <p>This release introduces major improvements since version 1.2.7.</p>
+        <ul>
+          <li>Improved general user experience (resizable window, more responsive GUI)</li>
+          <li>Improved joystick and controller support</li>
+          <li>Various bug fixes and stability improvements</li>
+          <li>Added support for 3rd-party episodes packed as .zip files</li>
+          <li>Introduced a new level format enabling more complex and customizable 3rd-party levels</li>
+          <li>Removed legacy filename limitations (e.g. 12-character limit)</li>
+          <li>Removed other legacy limits (e.g. 50 levels per episode, 600 sprites per level)</li>
+          <li>Improved modding support with a more flexible sprite system (compatible with 1.2.7 content) and new Lua scripting support</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.2.7" date="2020-09-20"/>
   </releases>
-  <content_rating type="oars-1.1"/>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">mild</content_attribute>
+  </content_rating>
 </component>

--- a/net.pistegamez.PekkaKana2.wrapper.sh
+++ b/net.pistegamez.PekkaKana2.wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 DATA_OLD="$(dirname "$XDG_DATA_HOME")/.pekka-kana-2"
 echo $DATA_OLD

--- a/net.pistegamez.PekkaKana2.wrapper.sh
+++ b/net.pistegamez.PekkaKana2.wrapper.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+DATA_OLD="$(dirname "$XDG_DATA_HOME")/.pekka-kana-2"
+echo $DATA_OLD
+
+DATA_NEW=$XDG_DATA_HOME
+
+# migrate saves.dat
+if [ ! -f "$DATA_NEW/saves.dat" ] && [ -f "$DATA_OLD/saves.dat" ]; then
+    mkdir -p "$DATA_NEW"
+    cp -a "$DATA_OLD/saves.dat" "$DATA_NEW/"
+fi
+
+# migrate scores
+SCORES_NEW="$DATA_NEW/scores"
+if [ ! -d "$SCORES_NEW" ] && [ -d "$DATA_OLD" ]; then
+    mkdir -p "$SCORES_NEW"
+
+    for dir in "$DATA_OLD"/*; do
+        [ -d "$dir" ] || continue
+
+        OLD_FILE="$dir/scores.dat"
+        [ -f "$OLD_FILE" ] || continue
+
+        BASENAME="$(basename "$dir")"
+
+        # change "-" to spaces
+
+        NAME="$(echo "$BASENAME" | tr '-' ' ')"
+        NEW_FILE="$SCORES_NEW/$NAME.dat"
+
+        if [ ! -f "$NEW_FILE" ]; then
+            cp -a "$OLD_FILE" "$NEW_FILE"
+        fi
+    done
+fi
+
+
+
+exec /app/share/games/pekka-kana-2/pekka-kana-2 \
+    --assets-path /app/share/games/pekka-kana-2 \
+    --data-path "$DATA_NEW"

--- a/net.pistegamez.PekkaKana2.yaml
+++ b/net.pistegamez.PekkaKana2.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
+  - --persist=.pekka-kana-2
 cleanup:
   - /include
   - /lib/cmake

--- a/net.pistegamez.PekkaKana2.yaml
+++ b/net.pistegamez.PekkaKana2.yaml
@@ -1,25 +1,22 @@
-app-id: net.pistegamez.PekkaKana2
+id: net.pistegamez.PekkaKana2
 runtime: org.freedesktop.Platform
-runtime-version: 24.08
+runtime-version: 25.08
 sdk: org.freedesktop.Sdk
 command: pekka-kana-2.sh
 finish-args:
-  # Controller support
-  - --device=all
+  - --device=all # Controller support
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
-  - --persist=.pekka-kana-2
-  - --filesystem=xdg-data/piste-gamez/pekka-kana-2:rw  #for better integration with the level editor
 cleanup:
-  - /man
   - /include
-  - /share/man
-  - /doc
-  - '*.a'
-  - '*.la'
+  - /lib/cmake
+  - /lib/pkgconfig
 modules:
+  - shared-modules/SDL2/SDL2_image.json
+  - shared-modules/lua5.4/lua-5.4.json
+
   - name: libmodplug
     sources:
       - type: archive
@@ -34,18 +31,8 @@ modules:
         url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
         sha256: cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
 
-  - shared-modules/lua5.4/lua-5.4.json
-
   - name: libzip
     buildsystem: cmake-ninja
-    config-opts:
-      - -DBUILD_SHARED_LIBS=ON
-      - -DENABLE_COMMONCRYPTO=OFF
-      - -DENABLE_GNUTLS=OFF
-      - -DENABLE_MBEDTLS=OFF
-      - -DENABLE_OPENSSL=OFF
-      - -DBUILD_TOOLS=OFF
-      - -DBUILD_REGRESS=OFF
     sources:
       - type: archive
         url: https://libzip.org/download/libzip-1.11.4.tar.gz
@@ -53,29 +40,30 @@ modules:
 
   - name: pekkakana2
     buildsystem: simple
+    build-options:
+      env:
+        C_INCLUDE_PATH: /app/include/SDL2:/app/include:/usr/include/SDL2
+        CPLUS_INCLUDE_PATH: /app/include/SDL2:/app/include:/usr/include/SDL2
+    build-commands:
+      - make -j$FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://github.com/SaturninTheAlien/pk2_greta/archive/refs/tags/1.5.1.zip
-        sha256: 33bf0557b38632efaad93a75ab4e61bdce3532dedde69d46fa6c01130d6b70c1
+        url: https://github.com/SaturninTheAlien/pk2_greta/archive/refs/tags/1.5.2.zip
+        sha256: 560195cc4bc2c920c0b37356fd710d6cd9cb79df845fa94beecc5d20295a81b1
       - type: file
         path: net.pistegamez.PekkaKana2.desktop
       - type: file
         path: net.pistegamez.PekkaKana2.png
       - type: file
         path: net.pistegamez.PekkaKana2.metainfo.xml
-      - type: script
-        commands:
-          - exec /app/share/games/pekka-kana-2/pekka-kana-2 --assets-path /app/share/games/pekka-kana-2 --data-path PREF_PATH
-        dest-filename: pekka-kana-2.sh
-    build-commands:
-      - make -j $FLATPAK_BUILDER_N_JOBS
+      - type: file
+        path: net.pistegamez.PekkaKana2.wrapper.sh
+        
+    post-install:
       - mkdir -p /app/share/games/pekka-kana-2
-      - install -Dm755 pekka-kana-2.sh /app/bin/pekka-kana-2.sh
+      - install -Dm755 net.pistegamez.PekkaKana2.wrapper.sh  /app/bin/pekka-kana-2.sh
       - install -Dm755 bin/pekka-kana-2 /app/share/games/pekka-kana-2/pekka-kana-2
-      - |
-        for dir in episodes gfx language music sfx sprites; do
-          cp -r res/$dir /app/share/games/pekka-kana-2/$dir
-        done
+      - cp -a res /app/share/games/pekka-kana-2
       - install -Dm644 net.pistegamez.PekkaKana2.desktop /app/share/applications/net.pistegamez.PekkaKana2.desktop
       - install -Dm644 net.pistegamez.PekkaKana2.png /app/share/icons/hicolor/128x128/apps/net.pistegamez.PekkaKana2.png
       - install -Dm644 net.pistegamez.PekkaKana2.metainfo.xml /app/share/metainfo/net.pistegamez.PekkaKana2.metainfo.xml

--- a/net.pistegamez.PekkaKana2.yaml
+++ b/net.pistegamez.PekkaKana2.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --persist=.pekka-kana-2
+  - --filesystem=xdg-data/piste-gamez/pekka-kana-2:rw  #for better integration with the level editor
 cleanup:
   - /man
   - /include
@@ -30,15 +31,32 @@ modules:
       - --enable-music-mod-modplug=yes
     sources:
       - type: archive
-        url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.2/SDL2_mixer-2.6.2.tar.gz
-        sha256: 8cdea810366decba3c33d32b8071bccd1c309b2499a54946d92b48e6922aa371
+        url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
+        sha256: cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
+
+  - shared-modules/lua5.4/lua-5.4.json
+
+  - name: libzip
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_SHARED_LIBS=ON
+      - -DENABLE_COMMONCRYPTO=OFF
+      - -DENABLE_GNUTLS=OFF
+      - -DENABLE_MBEDTLS=OFF
+      - -DENABLE_OPENSSL=OFF
+      - -DBUILD_TOOLS=OFF
+      - -DBUILD_REGRESS=OFF
+    sources:
+      - type: archive
+        url: https://libzip.org/download/libzip-1.11.4.tar.gz
+        sha256: 82e9f2f2421f9d7c2466bbc3173cd09595a88ea37db0d559a9d0a2dc60dc722e
 
   - name: pekkakana2
     buildsystem: simple
     sources:
       - type: archive
-        url: http://deb.debian.org/debian/pool/main/p/pekka-kana-2/pekka-kana-2_1.2.7.orig.tar.bz2
-        sha256: 07485c72173e5a3a87f55e8a749bf77526dae57cb1b34c5aa2eb0e17f7bd6f7b
+        url: https://github.com/SaturninTheAlien/pk2_greta/archive/refs/tags/1.5.1.zip
+        sha256: 33bf0557b38632efaad93a75ab4e61bdce3532dedde69d46fa6c01130d6b70c1
       - type: file
         path: net.pistegamez.PekkaKana2.desktop
       - type: file
@@ -47,7 +65,7 @@ modules:
         path: net.pistegamez.PekkaKana2.metainfo.xml
       - type: script
         commands:
-          - exec /app/share/games/pekka-kana-2/pekka-kana-2
+          - exec /app/share/games/pekka-kana-2/pekka-kana-2 --assets-path /app/share/games/pekka-kana-2 --data-path PREF_PATH
         dest-filename: pekka-kana-2.sh
     build-commands:
       - make -j $FLATPAK_BUILDER_N_JOBS
@@ -56,7 +74,7 @@ modules:
       - install -Dm755 bin/pekka-kana-2 /app/share/games/pekka-kana-2/pekka-kana-2
       - |
         for dir in episodes gfx language music sfx sprites; do
-          cp -r data/$dir /app/share/games/pekka-kana-2/$dir
+          cp -r res/$dir /app/share/games/pekka-kana-2/$dir
         done
       - install -Dm644 net.pistegamez.PekkaKana2.desktop /app/share/applications/net.pistegamez.PekkaKana2.desktop
       - install -Dm644 net.pistegamez.PekkaKana2.png /app/share/icons/hicolor/128x128/apps/net.pistegamez.PekkaKana2.png


### PR DESCRIPTION
**What's new**
This release includes many improvements to the general user experience, bug fixes, and several new features for level creators.
For a more detailed changelog, see:
https://github.com/SaturninTheAlien/pk2_greta/releases

I've added:
`--filesystem=xdg-data/piste-gamez/pekka-kana-2:rw`
to make sure the game data is saved in:
`~/.local/share/piste-gamez/pekka-kana-2,`
as users upload third-party episodes there.
This also makes integration with the level editor much more seamless.

Closes #7 (previous unfinished update attempt)