### PR TITLE
Add a note about intentional rebuild of SDL2_mixer

### DIFF
--- a/net.pistegamez.PekkaKana2.yaml
+++ b/net.pistegamez.PekkaKana2.yaml
@@ -21,6 +21,10 @@ modules:
   - shared-modules/SDL2/SDL2_image.json
   - shared-modules/lua5.4/lua-5.4.json
 
+    # NOTE: SDL2_mixer is rebuilt locally with libmodplug support to preserve XM module playback.
+    # The version provided by the Flathub runtime does not support XM music, so this duplication is intentional.
+    # This can be removed if the runtime SDL2_mixer gains XM support (e.g. via libmodplug or libxmp).
+
   - name: libmodplug
     sources:
       - type: archive

--- a/net.pistegamez.PekkaKana2.yaml
+++ b/net.pistegamez.PekkaKana2.yaml
@@ -24,7 +24,6 @@ modules:
     # NOTE: SDL2_mixer is rebuilt locally with libmodplug support to preserve XM module playback.
     # The version provided by the Flathub runtime does not support XM music, so this duplication is intentional.
     # This can be removed if the runtime SDL2_mixer gains XM support (e.g. via libmodplug or libxmp).
-
   - name: libmodplug
     sources:
       - type: archive


### PR DESCRIPTION
Added a note to the manifest to explain why SDL2_mixer is built locally (XM music support).
